### PR TITLE
Change the project overview in the README from a fake one to a real one

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,17 @@ Getting started guide to run the code for new users
 
 # Overview
 
-The improved-spork project consists of: 
-* `file1.py`: This file does... 
-* `file2.py`: This file is responsible for... 
-* `file3.py`: This file...
+The improved-spork project is an AI software engineering assistant that helps developers contribute clean, high-quality code to GitHub repositories. It provides the following functionality:
+* Automatically log into GitHub using an API key
+* List repositories and issues
+* Utilize an AI agent along with various tools (Python REPL, Terminal, and others) to close issues while adhering to the user's instructions
+
+The project consists of the following files:
+* `config.py`: Loads environment variables and stores required settings
+* `custom_tools.py`: Builds custom Git tools (git-branch, git-commit, git-create-pull-request) to interact with the Git repository
+* `main.py`: Logs into GitHub, selects a repository and issue, initializes the AI agent, and runs the task of closing the chosen issue
+* `utils.py`: Contains utility functions for GitHub interactions
+
 
 # Getting Started
 


### PR DESCRIPTION
The first cut of the project overview was written with fake info.
Understand the contents of the project, come up with real descriptions and summaries, and add them to the README in place of the fake one.