### PR TITLE
Add a "link reader" tool

### DIFF
--- a/custom_tools.py
+++ b/custom_tools.py
@@ -1,5 +1,5 @@
+from langchain import requests
 from langchain.agents import Tool
-
 
 class GitToolBuilder:
     def __init__(self, github_repo, pygit_repo, issue):
@@ -68,11 +68,3 @@ class GitToolBuilder:
         return (
             f"Created pull request for  {title} in {self.github_repo.name} repository."
         )
-
-import requests
-
-def read_link(link):
-    response = requests.get(link)
-    content = response.text
-    return content
-

--- a/main.py
+++ b/main.py
@@ -37,7 +37,7 @@ if pygit_repo.active_branch.name != "main":
 
 llm = ChatOpenAI(temperature=0, model="gpt-4")
 # llm1 = OpenAI(temperature=0)
-tools = load_tools(["python_repl", "terminal", "serpapi"], llm=llm)
+tools = load_tools(["python_repl", "terminal", "serpapi", "requests-get"], llm=llm)
 tools += GitToolBuilder(github_repo, pygit_repo, issue).build_tools()
 
 
@@ -54,8 +54,5 @@ task = (
 )
 exec_agent.run(task)
 
-from custom_tools import read_link
 
-link_content = read_link("https://example.com")
-print(link_content)
 


### PR DESCRIPTION
An issue often involves using external libraries, apis, and frameworks. To use them successfully, it is often necessary to read the documentation. 
The goal: if an issue contains a link, an agent should be able to read the contents of the website that link points to.
Implement a tool called read_link in custom_tools.py and integrate it in main.py