### PR TITLE
Change getting started section of readme to use the right filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ To run the code, follow these steps:
 
 1. Clone the repository on your local machine.
 2. Navigate to the project directory.
-3. Run `python file1.py` to execute the main script.
+3. Install required dependencies by running `pip install -r requirements.txt`
+3. Run `python main.py` to execute the main script.


### PR DESCRIPTION
Right now the README contains a getting started section which instructs the user to run file1.py. This is not a real file in this project. This should be main.py
Also, before this step, a user should install requirements, so we need to add a step for that.